### PR TITLE
fix: remove previousVolume from controller.

### DIFF
--- a/demo/story.tsx
+++ b/demo/story.tsx
@@ -33,7 +33,7 @@ const Sentence: ComponentStory<typeof TextToSpeech> = (args) => {
     </TextToSpeech>
   )
 }
-const LocaleEsES: ComponentStory<typeof TextToSpeech> = (args) => {
+const LangLocale: ComponentStory<typeof TextToSpeech> = (args) => {
   const esVoices = voices.filter((voice) => voice.lang === 'es-ES')
   const voice = esVoices.find((voice) => voice.name === 'Monica') ?? esVoices[0]
 
@@ -48,12 +48,13 @@ const LocaleEsES: ComponentStory<typeof TextToSpeech> = (args) => {
     </>
   )
 }
-const UseStopOverPause: ComponentStory<typeof TextToSpeech> = (args) => {
+const Android: ComponentStory<typeof TextToSpeech> = (args) => {
   return (
     <TextToSpeech {...args} useStopOverPause>
       <p>
         On Android <code>SpeechSynthesis.pause()</code> behaves like <code>cancel()</code>
-        .
+        . <code>useStopOverPause</code> changes the component&apos;s pause control to a
+        stop as shown here.
       </p>
     </TextToSpeech>
   )
@@ -90,20 +91,22 @@ const RandomText: ComponentStory<typeof TextToSpeech> = (args) => {
 const Hook: ComponentStory<typeof TextToSpeech> = (args) => {
   const { ttsChildren, onPlay, onPause, onReset, onStop } = useTts({
     ...args,
-    children: 'Use the hook to create controls with custom styling.'
+    children: 'The hook can be used to create custom controls.'
   })
 
   return (
-    <div>
-      <button onClick={onPlay}>Play</button>
-      <button onClick={onPause}>Pause</button>
-      <button onClick={onStop}>Stop</button>
-      <button onClick={onReset}>Reset</button>
-      <div>{ttsChildren}</div>
-    </div>
+    <>
+      <div style={{ display: 'flex', gap: '5px' }}>
+        <button onClick={onPlay}>Play</button>
+        <button onClick={onPause}>Pause</button>
+        <button onClick={onStop}>Stop</button>
+        <button onClick={onReset}>Reset</button>
+      </div>
+      <p>{ttsChildren}</p>
+    </>
   )
 }
-const StandardExample: ComponentStory<typeof TextToSpeech> = (args) => {
+const Component: ComponentStory<typeof TextToSpeech> = (args) => {
   return (
     <TextToSpeech {...args} position={Positions.TL} align="vertical">
       <div style={{ minWidth: '300px', paddingLeft: '60px' }}>
@@ -219,7 +222,7 @@ const AmazonPolly: ComponentStory<typeof TextToSpeech> = (args) => {
   )
 }
 
-StandardExample.argTypes = {
+Component.argTypes = {
   voice: {
     control: false
   },
@@ -249,14 +252,14 @@ Hook.argTypes = {
     control: false
   }
 }
-UseStopOverPause.argTypes = {
+Android.argTypes = {
   useStopOverPause: {
     control: false
   }
 }
 
 export default {
-  title: 'Demo/TextToSpeech',
+  title: 'tts-react',
   component: TextToSpeech,
   args: {
     autoPlay: false,
@@ -315,12 +318,12 @@ export default {
 } as ComponentMeta<typeof TextToSpeech>
 
 export {
-  StandardExample,
-  LocaleEsES,
   Hook,
+  Component,
+  LangLocale,
   AmazonPolly,
   ImageText,
-  UseStopOverPause,
+  Android,
   Sentence,
   RandomSentence,
   RandomText,

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -15,10 +15,15 @@ enum Positions {
   BR = 'bottomRight'
 }
 interface TTSProps extends TTSHookProps {
+  /** How the controls are aligned within the `TextToSpeech` component. */
   align?: 'vertical' | 'horizontal'
+  /** The relative size of the controls within the `TextToSpeech` component. */
   size?: SvgProps['size']
+  /** The relative position of the controls within the `TextToSpeech` component. */
   position?: `${Positions}`
+  /** Whether the `TextToSpeech` component should render the audio toggling control. */
   allowMuting?: boolean
+  /** Whether the `TextToSpeech` should render a stop control instead of pause. */
   useStopOverPause?: boolean
 }
 type ControlsProps = Required<Pick<TTSProps, 'align' | 'position' | 'size'>>

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -50,7 +50,6 @@ class Controller extends EventTarget {
   protected readonly dispatchBoundaries: boolean = false
   protected fetchAudioData: FetchAudioData
   protected marks: PollySpeechMark[] = []
-  protected previousVolume = 1
   protected locale = ''
 
   constructor(options: ControllerOptions) {
@@ -349,7 +348,6 @@ class Controller extends EventTarget {
   }
 
   mute(): void {
-    this.previousVolume = this.volume
     this.volume = 0
 
     /**
@@ -365,8 +363,8 @@ class Controller extends EventTarget {
     }
   }
 
-  unmute(): void {
-    this.volume = this.previousVolume ?? 1
+  unmute(volume?: number): void {
+    this.volume = volume ?? 1
 
     if (!(this.synthesizer instanceof HTMLAudioElement)) {
       this.clear()

--- a/src/hook.tsx
+++ b/src/hook.tsx
@@ -20,18 +20,28 @@ import { isStringOrNumber, stripPunctuation } from './utils'
 import { Highlighter } from './highlighter'
 
 interface MarkStyles {
+  /** Text color of the currently marked word. */
   markColor?: string
+  /** Background color of the currently marked word. */
   markBackgroundColor?: string
 }
 interface TTSHookProps extends MarkStyles {
-  lang?: ControllerOptions['lang']
-  autoPlay?: boolean
+  /** The spoken text is extracted from here. */
   children: ReactNode
-  markTextAsSpoken?: boolean
-  onMuted?: (muted: boolean) => void
-  onError?: (errorMsg: string) => void
-  fetchAudioData?: ControllerOptions['fetchAudioData']
+  /** The `SpeechSynthesisUtterance.lang` to use. */
+  lang?: ControllerOptions['lang']
+  /** The `SpeechSynthesisUtterance.voice` to use. */
   voice?: ControllerOptions['voice']
+  /** Whether the text should be spoken automatically, i.e. on render. */
+  autoPlay?: boolean
+  /** Whether the spoken word should be wrapped in a `<mark>` element. */
+  markTextAsSpoken?: boolean
+  /** Callback when the volume toggle button is clicked. */
+  onMuted?: (wasMuted: boolean) => void
+  /** Callback when there is an error of any kind. */
+  onError?: (errorMsg: string) => void
+  /** Function to fetch audio and speech marks for the spoken text. */
+  fetchAudioData?: ControllerOptions['fetchAudioData']
 }
 interface TTSHookState {
   boundary: TTSBoundaryUpdate


### PR DESCRIPTION
* Removes use of `previousVolume` from controller in favor of passing a `volume` argument to the controller's `unmute` method. This allows `onMuted` to have its volume correctly restored.
* Adds type comments to be picked up by Storybook's docgen.