### PR TITLE
refactor: memoize reference to controller event listeners.

### DIFF
--- a/__tests__/hook.tsx
+++ b/__tests__/hook.tsx
@@ -45,6 +45,12 @@ describe('useTts', () => {
     // Check default state
     expect(result.current.state).toStrictEqual(defaultState)
 
+    // Check that voices get updated
+    act(() => {
+      global.speechSynthesis.dispatchEvent(new Event('voiceschanged'))
+    })
+    expect(global.speechSynthesis.getVoices).toHaveBeenCalled()
+
     // Start coverting text to speech
     act(() => {
       result.current.onPlay()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tts-react",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tts-react",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-react",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "React component to convert text to speech.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
* Refactor to memoize reference to controller event listeners.
* Use `addEventListener` for `voiceschanged` event.
* Add a test to cover the updating of voices when `voiceschanged` fires.