### PR TITLE
refactor: decouple controller instantiation from changing spokenText.

### DIFF
--- a/__tests__/controller.ts
+++ b/__tests__/controller.ts
@@ -49,7 +49,6 @@ describe('Controller', () => {
   it("wraps parts of the SpeechSynthesis and HTMLAudioElement API's", () => {
     const voice = global.speechSynthesis.getVoices()[0]
     const controller = new Controller({
-      text: SpeechSynthesisMock.textForTest,
       lang: 'en-US',
       dispatchBoundaries: true,
       voice
@@ -59,6 +58,7 @@ describe('Controller', () => {
       global.speechSynthesis.onvoiceschanged(new Event('voiceschanged'))
     }
 
+    controller.spokenText = SpeechSynthesisMock.textForTest
     controller.init()
 
     expect(controller.lang).toBe('en-US')
@@ -100,8 +100,7 @@ describe('Controller', () => {
     )
     const controller = new Controller({
       fetchAudioData,
-      dispatchBoundaries: true,
-      text: SpeechSynthesisMock.textForTest
+      dispatchBoundaries: true
     })
     const synth = controller.synth as HTMLAudioElement
 
@@ -110,6 +109,7 @@ describe('Controller', () => {
       synth.dispatchEvent(new Event('timeupdate'))
     })
 
+    controller.spokenText = SpeechSynthesisMock.textForTest
     // Wait for the fetchAudioData promise to resolve
     await controller.init()
 
@@ -153,13 +153,13 @@ describe('Controller', () => {
       Promise.reject(new Error())
     )
     const controller = new Controller({
-      fetchAudioData,
-      text: SpeechSynthesisMock.textForTest
+      fetchAudioData
     })
     // No distinction between synthesizer and target when using fetchAudioData
     const synth = controller.utter as HTMLAudioElement
     const onControllerError = jest.fn()
 
+    controller.spokenText = SpeechSynthesisMock.textForTest
     controller.addEventListener(Events.ERROR, onControllerError)
 
     await controller.init()
@@ -175,10 +175,9 @@ describe('Controller', () => {
 
   it('dispatches pause events when calling pause on an utterance', async () => {
     const onPaused = jest.fn()
-    const controller = new Controller({
-      text: SpeechSynthesisMock.textForTest
-    })
+    const controller = new Controller()
 
+    controller.spokenText = SpeechSynthesisMock.textForTest
     controller.addEventListener(Events.PAUSED, onPaused)
 
     await controller.init()

--- a/demo/story.tsx
+++ b/demo/story.tsx
@@ -1,6 +1,6 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react'
 import { faker } from '@faker-js/faker'
-import { useRef, useState, useEffect, useCallback } from 'react'
+import { useRef, useState, useEffect, useCallback, useMemo } from 'react'
 import type { ChangeEventHandler, ChangeEvent, ReactNode } from 'react'
 import parse from 'html-react-parser'
 import { action } from '@storybook/addon-actions'
@@ -165,9 +165,9 @@ const Hook: ComponentStory<typeof TextToSpeech> = (args) => {
       ...args,
       voice,
       children: 'The hook can be used to create custom controls.',
-      onVolumeChange: action('onVolumeChange'),
-      onPitchChange: action('onPitchChange'),
-      onRateChange: action('onRateChange')
+      onVolumeChange: useMemo(() => action('onVolumeChange'), []),
+      onPitchChange: useMemo(() => action('onPitchChange'), []),
+      onRateChange: useMemo(() => action('onRateChange'), [])
     })
   const onMuteChanged = useCallback(() => {
     onToggleMute((wasMuted) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tts-react",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tts-react",
-      "version": "0.6.4",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-react",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "React component to convert text to speech.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -40,7 +40,6 @@ interface CustomNumberEventListener {
   (evt: CustomEvent<number>): void
 }
 interface ControllerOptions {
-  text: string
   lang?: string
   voice?: SpeechSynthesisVoice
   dispatchBoundaries?: boolean
@@ -50,34 +49,33 @@ type Target = HTMLAudioElement | SpeechSynthesisUtterance
 type Synthesizer = HTMLAudioElement | SpeechSynthesis
 
 class Controller extends EventTarget {
-  protected readonly text: string
   protected readonly target: Target
   protected readonly synthesizer: Synthesizer
   protected readonly dispatchBoundaries: boolean = false
   protected fetchAudioData: FetchAudioData
   protected marks: PollySpeechMark[] = []
+  protected text = ''
   protected locale = ''
   protected initialized = false
 
-  constructor(options: ControllerOptions) {
+  constructor(options?: ControllerOptions) {
     super()
 
-    this.text = options.text
     this.locale = options?.lang ?? this.locale
     this.synthesizer = window.speechSynthesis
-    this.target = new SpeechSynthesisUtterance(options.text)
+    this.target = new SpeechSynthesisUtterance(this.text)
     this.fetchAudioData = async () => ({ audio: '', marks: [] })
-    this.dispatchBoundaries = options.dispatchBoundaries ?? this.dispatchBoundaries
+    this.dispatchBoundaries = options?.dispatchBoundaries ?? this.dispatchBoundaries
 
-    if (options.fetchAudioData) {
+    if (options?.fetchAudioData) {
       this.target = this.synthesizer = new Audio()
       this.fetchAudioData = options.fetchAudioData
     } else {
-      this.initWebSpeechVoice(options.voice)
+      this.initWebSpeechVoice(options?.voice)
 
       if (window.speechSynthesis) {
         window.speechSynthesis.onvoiceschanged = () => {
-          this.initWebSpeechVoice(options.voice)
+          this.initWebSpeechVoice(options?.voice)
         }
       }
     }
@@ -211,6 +209,14 @@ class Controller extends EventTarget {
     }
 
     return this.target as HTMLAudioElement
+  }
+
+  set spokenText(value: string) {
+    this.text = value
+
+    if (this.target instanceof SpeechSynthesisUtterance) {
+      this.target.text = value
+    }
   }
 
   get paused(): boolean {

--- a/src/hook.tsx
+++ b/src/hook.tsx
@@ -257,10 +257,9 @@ const useTts = ({
         lang,
         voice,
         fetchAudioData,
-        text: spokenText,
         dispatchBoundaries: markTextAsSpoken
       }),
-    [lang, voice, fetchAudioData, spokenText, markTextAsSpoken]
+    [lang, voice, fetchAudioData, markTextAsSpoken]
   )
   const onPlay = useCallback(() => {
     if (state.isPaused) {
@@ -403,6 +402,10 @@ const useTts = ({
     },
     [onRateChange]
   )
+
+  useEffect(() => {
+    controller.spokenText = spokenText
+  }, [spokenText, controller])
 
   useEffect(() => {
     const onBeforeUnload = () => {


### PR DESCRIPTION
* Adds a `spokenText` setter to the controller.
* Removes `spokenText` from the `useEffect` dependencies that control instantiation of the backing controller, so new controllers aren't created when the spokenText changes from being marked.