### PR TITLE
fix: only fire boundary events if word or marks found.

### DIFF
--- a/__tests__/controller.ts
+++ b/__tests__/controller.ts
@@ -46,7 +46,7 @@ describe('Controller', () => {
     ]
   }
 
-  it("wraps parts of the SpeechSynthesis and HTMLAudioElement API's", () => {
+  it("wraps parts of the SpeechSynthesis and HTMLAudioElement API's", async () => {
     const voice = global.speechSynthesis.getVoices()[0]
     const controller = new Controller({
       lang: 'en-US',
@@ -59,7 +59,7 @@ describe('Controller', () => {
     }
 
     controller.spokenText = SpeechSynthesisMock.textForTest
-    controller.init()
+    await controller.init()
 
     expect(controller.lang).toBe('en-US')
     expect(controller.rate).toBe(1)
@@ -148,7 +148,7 @@ describe('Controller', () => {
     expect(controller.pitch).toBe(-1)
   })
 
-  it('catches and dispatches fetchAudioData or play errors', async () => {
+  it('catches and dispatches fetchAudioData, play, and event errors', async () => {
     const fetchAudioData = jest.fn<Promise<TTSAudioData>, [string]>(() =>
       Promise.reject(new Error())
     )
@@ -171,6 +171,9 @@ describe('Controller', () => {
       .mockImplementationOnce(() => Promise.reject(new Error()))
     await controller.play()
     expect(onControllerError).toHaveBeenCalledTimes(2)
+
+    synth.dispatchEvent(new Event('error'))
+    expect(onControllerError).toHaveBeenCalledTimes(3)
   })
 
   it('dispatches pause events when calling pause on an utterance', async () => {

--- a/__tests__/speechSynthesis.mock.ts
+++ b/__tests__/speechSynthesis.mock.ts
@@ -45,8 +45,6 @@ class SpeechSynthesisMock extends EventTarget {
     let word = words.shift()
 
     this.#abortController.signal.onabort = () => {
-      //console.log('onAbort called, pushing utterance entry', words)
-
       this.#utterances.unshift({ utterance: entry.utterance, words: [...words] })
       this.#speaking = false
     }
@@ -94,7 +92,6 @@ class SpeechSynthesisMock extends EventTarget {
     }
 
     if (this.#speaking && this.#abortController) {
-      //console.log('abort from cancel')
       this.#abortController.abort()
     }
 
@@ -124,11 +121,9 @@ class SpeechSynthesisMock extends EventTarget {
     this.#paused = false
 
     if (entry) {
-      //console.log('on resume found entry', entry.words)
       const numWords = SpeechSynthesisMock.getWords(entry.utterance.text).length
       const numWordsLeft = entry.words.length
 
-      //this.speak(entry.utterance)
       entry.utterance.dispatchEvent(
         new SpeechSynthesisEventMock(numWordsLeft === numWords ? 'start' : 'resume', {
           utterance: entry.utterance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tts-react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tts-react",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "React component to convert text to speech.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -344,7 +344,7 @@ class Controller extends EventTarget {
             const endChar = startChar + charLength
             const word = this.text.substring(startChar, endChar)
 
-            if (!isPunctuation(word)) {
+            if (word && !isPunctuation(word)) {
               this.dispatchBoundary({ word, startChar, endChar })
             }
           })
@@ -354,12 +354,14 @@ class Controller extends EventTarget {
       }
 
       if (this.target instanceof HTMLAudioElement) {
+        const target = this.target
+
         this.target.addEventListener('ended', this.dispatchEnd.bind(this))
         this.target.addEventListener('canplay', this.dispatchReady.bind(this), {
           once: true
         })
         this.target.addEventListener('error', () => {
-          const error = (this.target as HTMLAudioElement).error
+          const error = target.error
 
           this.dispatchError(error?.message)
         })
@@ -367,10 +369,10 @@ class Controller extends EventTarget {
         if (this.dispatchBoundaries) {
           this.target.addEventListener('timeupdate', () => {
             // Polly Speech Marks use milliseconds
-            const currentTime = (this.target as HTMLAudioElement).currentTime * 1000
+            const currentTime = target.currentTime * 1000
             const mark = this.getPollySpeechMarkForAudioTime(currentTime)
 
-            if (!this.paused) {
+            if (mark && !this.paused) {
               this.dispatchBoundary({
                 word: mark.value,
                 startChar: mark.start,


### PR DESCRIPTION
* Only fire boundary events when there is something to report.
* Refactor to remove some type assertions.