### PR TITLE
feat: add onEnd, rate, and volume parameters to useTts.

### DIFF
--- a/__tests__/hook.tsx
+++ b/__tests__/hook.tsx
@@ -31,10 +31,15 @@ describe('useTts', () => {
   })
 
   test('it converts text-to-speech from children text and updates state on word boundaries', async () => {
+    const onEnd = jest.fn()
     const { result, waitForNextUpdate } = renderHook(
-      ({ children, markTextAsSpoken }) => useTts({ children, markTextAsSpoken }),
+      ({ children, markTextAsSpoken, onEnd, rate, volume }) =>
+        useTts({ children, markTextAsSpoken, onEnd, rate, volume }),
       {
         initialProps: {
+          onEnd,
+          rate: 0.4,
+          volume: 0.5,
           markTextAsSpoken: true,
           children: <p>{SpeechSynthesisMock.textForTest}</p>
         }
@@ -56,6 +61,8 @@ describe('useTts', () => {
       result.current.onPlay()
     })
     expect(result.current.state.isPlaying).toBe(true)
+    expect(result.current.get.rate()).toBe(0.4)
+    expect(result.current.get.volume()).toBe(0.5)
     expect(global.speechSynthesis.speak).toHaveBeenCalled()
 
     // Check firing of word boundaries and state boundary updates
@@ -74,6 +81,7 @@ describe('useTts', () => {
     })
     await waitForNextUpdate()
     expect(result.current.state.isPlaying).toBe(false)
+    expect(onEnd).toHaveBeenCalled()
   })
 
   it('allows pausing, resuming and stopping of spoken text', () => {

--- a/demo/story.tsx
+++ b/demo/story.tsx
@@ -167,7 +167,10 @@ const Hook: ComponentStory<typeof TextToSpeech> = (args) => {
       children: 'The hook can be used to create custom controls.',
       onVolumeChange: useMemo(() => action('onVolumeChange'), []),
       onPitchChange: useMemo(() => action('onPitchChange'), []),
-      onRateChange: useMemo(() => action('onRateChange'), [])
+      //onRateChange: useMemo(() => action('onRateChange'), [])
+      onRateChange: useCallback((newRate) => {
+        setRate(newRate)
+      }, [])
     })
   const onMuteChanged = useCallback(() => {
     onToggleMute((wasMuted) => {
@@ -292,7 +295,7 @@ const Hook: ComponentStory<typeof TextToSpeech> = (args) => {
             min="0.1"
             max="4"
             step="0.1"
-            defaultValue={'1'}
+            defaultValue="1"
             disabled={state.isPlaying}
             onChange={onRateHandler}
           />
@@ -457,6 +460,12 @@ Hook.argTypes = {
   },
   useStopOverPause: {
     control: false
+  },
+  rate: {
+    control: false
+  },
+  volume: {
+    control: false
   }
 }
 SpeakComponent.argTypes = {
@@ -490,6 +499,8 @@ export default {
   component: TextToSpeech,
   args: {
     autoPlay: false,
+    rate: 1,
+    volume: 1,
     size: Sizes.MEDIUM,
     allowMuting: true,
     align: 'horizontal',
@@ -510,6 +521,22 @@ export default {
     },
     voice: {
       control: false
+    },
+    rate: {
+      control: {
+        type: 'number',
+        min: 0.1,
+        max: 4,
+        step: 0.1
+      }
+    },
+    volume: {
+      control: {
+        type: 'number',
+        min: 0,
+        max: 1,
+        step: 0.1
+      }
     },
     children: {
       control: false

--- a/demo/story.tsx
+++ b/demo/story.tsx
@@ -167,10 +167,7 @@ const Hook: ComponentStory<typeof TextToSpeech> = (args) => {
       children: 'The hook can be used to create custom controls.',
       onVolumeChange: useMemo(() => action('onVolumeChange'), []),
       onPitchChange: useMemo(() => action('onPitchChange'), []),
-      //onRateChange: useMemo(() => action('onRateChange'), [])
-      onRateChange: useCallback((newRate) => {
-        setRate(newRate)
-      }, [])
+      onRateChange: useMemo(() => action('onRateChange'), [])
     })
   const onMuteChanged = useCallback(() => {
     onToggleMute((wasMuted) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tts-react",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tts-react",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-react",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "React component to convert text to speech.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -80,7 +80,9 @@ const controls = ({ align, position, size }: ControlsProps): CSSProperties => {
  */
 const TextToSpeech = ({
   lang,
+  rate,
   voice,
+  volume,
   children,
   onError,
   onMuteToggled,
@@ -97,7 +99,9 @@ const TextToSpeech = ({
 }: TTSProps) => {
   const { state, onReset, onToggleMute, onPlayPause, onPlayStop, ttsChildren } = useTts({
     lang,
+    rate,
     voice,
+    volume,
     children,
     onError,
     fetchAudioData,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -236,6 +236,7 @@ class Controller extends EventTarget {
 
     if (!Number.isNaN(clamped)) {
       if (this.synthesizer instanceof HTMLAudioElement) {
+        this.synthesizer.defaultPlaybackRate = clamped
         this.synthesizer.playbackRate = clamped
       }
 
@@ -390,7 +391,9 @@ class Controller extends EventTarget {
   }
 
   async play(): Promise<void> {
-    if (this.synthesizer instanceof HTMLAudioElement) {
+    if (this.paused) {
+      await this.resume()
+    } else if (this.synthesizer instanceof HTMLAudioElement) {
       await this.playHtmlAudio()
     } else {
       this.synthesizer.speak(this.target as SpeechSynthesisUtterance)


### PR DESCRIPTION
* Adds `onEnd` callback that gets invoked for [`SpeechSynthesisUtterance.end`](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisUtterance/end_event) and [`HTMLMediaElement.ended`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/ended) events.
* Adds  a `rate` parameter to set the initial [`SpeechSynthesisUtterance.rate`](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisUtterance/rate) or the [`HTMLMediaElement.defaultPlaybackRate`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/defaultPlaybackRate).
* Adds a `volume` parameter to set the volume.
* Delegates handling of resume/play to the controller class behind `useTts`.

The `volume` and `rate` are clamped by their respective specs (HTMLMediaElement or SpeechSynthesisUtterance).