### PR TITLE
feat: add more event callbacks, passing event to handlers.

### DIFF
--- a/__tests__/component.tsx
+++ b/__tests__/component.tsx
@@ -24,6 +24,7 @@ describe('TextToSpeech', () => {
       fireEvent.click(getByRole('button', { name: 'Play' }))
     })
     expect(global.speechSynthesis.cancel).toHaveBeenCalled()
+    expect(global.speechSynthesis.resume).toHaveBeenCalled()
     expect(global.speechSynthesis.speak).toHaveBeenCalled()
     expect(getByRole('button', { name: 'Pause' })).toBeInTheDocument()
 
@@ -40,9 +41,9 @@ describe('TextToSpeech', () => {
       fireEvent.click(getByRole('button', { name: 'Mute' }))
     })
     expect(onMuteToggled).toHaveBeenCalledWith(false)
-    // Cancel only called once thus far as we are currently paused (so no reset)
+    // Cancel only called once thus far as we are currently paused (so no replay)
     expect(global.speechSynthesis.cancel).toHaveBeenCalledTimes(1)
-    expect(global.speechSynthesis.resume).not.toHaveBeenCalled()
+    expect(global.speechSynthesis.resume).toHaveBeenCalledTimes(1)
     expect(global.speechSynthesis.speak).toHaveBeenCalledTimes(1)
   })
 

--- a/__tests__/speechSynthesisErrorEvent.mock.ts
+++ b/__tests__/speechSynthesisErrorEvent.mock.ts
@@ -1,0 +1,17 @@
+import { SpeechSynthesisEventMock } from './speechSynthesisEvent.mock'
+
+class SpeechSynthesisErrorEventMock extends SpeechSynthesisEventMock {
+  #error = ''
+
+  constructor(type: string, init: SpeechSynthesisEventInit) {
+    super(type, init)
+
+    this.#error = 'synthesis-failed'
+  }
+
+  get error() {
+    return this.#error
+  }
+}
+
+export { SpeechSynthesisErrorEventMock }

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,7 +7,7 @@ import { useTts } from 'tts-reat'
 const CountOnEnd = () => {
   const [count, setCount] = useState(1)
   const [counting, setCounting] = useState(false)
-  const { ttsChildren, onPlay } = useTts({
+  const { ttsChildren, play } = useTts({
     children: count,
     markTextAsSpoken: true,
     onEnd: useCallback(() => {
@@ -17,9 +17,9 @@ const CountOnEnd = () => {
 
   useEffect(() => {
     if (counting) {
-      onPlay()
+      play()
     }
-  }, [count, counting, onPlay])
+  }, [count, counting, play])
 
   return (
     <>

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -13,7 +13,7 @@ beforeEach(() => {
   jest.useFakeTimers()
 })
 
-afterEach(() => {
+afterEach(async () => {
   jest.clearAllMocks()
-  jest.runAllTimers()
+  jest.clearAllTimers()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tts-react",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tts-react",
-      "version": "0.8.2",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-react",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "description": "React component to convert text to speech.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -49,7 +49,7 @@ const wrap = (): CSSProperties => {
 }
 const controls = ({ align, position, size }: ControlsProps): CSSProperties => {
   return {
-    display: 'flex',
+    display: 'inline-flex',
     flexDirection: align === 'horizontal' ? 'row' : 'column',
     position: 'absolute',
     ...getTRBL(position),
@@ -84,8 +84,15 @@ const TextToSpeech = ({
   voice,
   volume,
   children,
+  onStart,
+  onPause,
+  onBoundary,
+  onEnd,
   onError,
   onMuteToggled,
+  onVolumeChange,
+  onPitchChange,
+  onRateChange,
   fetchAudioData,
   markColor,
   markBackgroundColor,
@@ -97,13 +104,20 @@ const TextToSpeech = ({
   markTextAsSpoken = false,
   useStopOverPause = false
 }: TTSProps) => {
-  const { state, onReset, onToggleMute, onPlayPause, onPlayStop, ttsChildren } = useTts({
+  const { state, replay, toggleMute, playOrPause, playOrStop, ttsChildren } = useTts({
     lang,
     rate,
     voice,
     volume,
     children,
+    onStart,
+    onPause,
+    onBoundary,
+    onEnd,
     onError,
+    onVolumeChange,
+    onPitchChange,
+    onRateChange,
     fetchAudioData,
     autoPlay,
     markColor,
@@ -118,17 +132,17 @@ const TextToSpeech = ({
   const [type, title, onClick] = useMemo(() => {
     if (state.isPlaying) {
       if (useStopOverPause) {
-        return ['stop', 'Stop', onPlayStop]
+        return ['stop', 'Stop', playOrStop]
       }
 
-      return ['pause', 'Pause', onPlayPause]
+      return ['pause', 'Pause', playOrPause]
     }
 
-    return ['play', 'Play', onPlayPause]
-  }, [state.isPlaying, useStopOverPause, onPlayStop, onPlayPause])
+    return ['play', 'Play', playOrPause]
+  }, [state.isPlaying, useStopOverPause, playOrStop, playOrPause])
   const handleOnMuteClicked = useCallback(() => {
-    onToggleMute(onMuteToggled)
-  }, [onToggleMute, onMuteToggled])
+    toggleMute(onMuteToggled)
+  }, [toggleMute, onMuteToggled])
 
   return (
     <div style={wrapStyle} className="tts-react">
@@ -158,7 +172,7 @@ const TextToSpeech = ({
               size={size}
               title="Replay"
               aria-label="Replay"
-              onClick={onReset}
+              onClick={replay}
             />
           )}
         </aside>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,13 @@ export { useTts } from './hook'
 export { LangCodes } from './utils'
 
 export type { TTSProps } from './component'
-export type { TTSHookProps, TTSHookResponse, TTSHookState } from './hook'
+export type {
+  TTSHookProps,
+  TTSHookResponse,
+  TTSHookState,
+  TTSEventHandler,
+  TTSBoundaryHandler,
+  TTSAudioChangeHandler,
+  TTSErrorHandler
+} from './hook'
 export type { TTSBoundaryUpdate, TTSAudioData, PollySpeechMark } from './controller'


### PR DESCRIPTION
BREAKING CHANGE: onReset renamed to replay, onPlay renamed to play, onStop renamed to stop, onPause renamed to pause, onToggleMute renamed to toggleMute, onPlayPause renamed to playOrPause, onPlayStop renamed to playOrStop.

* Changes to test mocks.
* Adds `onStart`, `onBoundary` and `onPause` while passing corresponding event objects to callbacks.
* Updates controller syntax to use es6 private class fields instead of TS `protected`.
* Updates README, docs and stories.