### PR TITLE
fix: isPlaying state cross-browser, FOUC in component.

### DIFF
--- a/__tests__/control.tsx
+++ b/__tests__/control.tsx
@@ -16,7 +16,7 @@ describe('Control', () => {
     fireEvent.click(getByRole('button', { name: 'Test' }))
     expect(onClick).toHaveBeenCalled()
 
-    // Check that styles corresponding to alignment correctly
+    // Check that styles correspond to alignment correctly
     rerender(<Control title="Align" type="replay" align="vertical" onClick={onClick} />)
     expect(getByRole('button', { name: 'Align' })).toHaveStyle({ bottom: '-39px' })
   })

--- a/__tests__/control.tsx
+++ b/__tests__/control.tsx
@@ -16,8 +16,8 @@ describe('Control', () => {
     fireEvent.click(getByRole('button', { name: 'Test' }))
     expect(onClick).toHaveBeenCalled()
 
-    // Check that the size defaults correctly
-    rerender(<Control title="NoSize" type="play" onClick={onClick} size={undefined} />)
-    expect(getByRole('button', { name: 'NoSize' })).toHaveStyle({ padding: '5px' })
+    // Check that styles corresponding to alignment correctly
+    rerender(<Control title="Align" type="replay" align="vertical" onClick={onClick} />)
+    expect(getByRole('button', { name: 'Align' })).toHaveStyle({ bottom: '-39px' })
   })
 })

--- a/__tests__/hook.tsx
+++ b/__tests__/hook.tsx
@@ -140,6 +140,7 @@ describe('useTts', () => {
     })
     await advanceBy(1)
     expect(global.speechSynthesis.resume).toHaveBeenCalled()
+    expect(global.speechSynthesis.cancel).toHaveBeenCalled()
     expect(result.current.state.isPaused).toBe(false)
     expect(result.current.state.isPlaying).toBe(true)
     expect(result.current.state.boundary.word).toBe(words[1])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tts-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tts-react",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React hook and component for converting text to speech using the Web Speech API or Amazon Polly.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/control.tsx
+++ b/src/control.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect } from 'react'
-import type { MouseEventHandler } from 'react'
+import type { MouseEventHandler, CSSProperties } from 'react'
 
 import { Sizes, icons, iconSizes } from './icons'
 
@@ -10,11 +10,42 @@ interface ControlProps {
   type: 'play' | 'stop' | 'pause' | 'replay' | 'volumeDown' | 'volumeOff' | 'volumeUp'
   onClick: MouseEventHandler<HTMLButtonElement>
 }
+type ButtonStyleProps = Required<Pick<ControlProps, 'size' | 'align' | 'type'>>
 
 const padding = {
   [Sizes.SMALL]: 5,
   [Sizes.MEDIUM]: 5,
   [Sizes.LARGE]: 5
+}
+const button = ({ size, align, type }: ButtonStyleProps): CSSProperties => {
+  const styles = {
+    margin: 0,
+    padding: `${padding[size]}px`,
+    border: 'none',
+    borderRadius: `${iconSizes[size]}px`,
+    color: 'black',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'transparent'
+  }
+
+  if (type === 'replay') {
+    // Include left/right padding + gutter
+    const value = `-${iconSizes[size] + 2 * padding[size] + 5}px`
+    const property = align === 'horizontal' ? 'right' : 'bottom'
+
+    return {
+      ...styles,
+      [property]: value,
+      position: 'absolute',
+      background: '#f2f1f1a6',
+      zIndex: 9999
+    }
+  }
+
+  return styles
 }
 const Control = ({
   title,
@@ -24,49 +55,35 @@ const Control = ({
   align = 'horizontal',
   ...rest
 }: ControlProps) => {
+  const styleDataId = 'tts-react-controls'
   const svg = useMemo(() => {
     return icons[type]({ size })
   }, [type, size])
+  const btnStyle = useMemo(() => button({ size, align, type }), [size, align, type])
 
   useEffect(() => {
-    const styleDataId = 'tts-react-controls'
-    const shift = iconSizes[size] + 2 * padding[size] + 5
-    const trbl = align === 'horizontal' ? `right: -${shift}px` : `bottom: -${shift}px`
+    // Keep pseudo styles in stylesheets where they are supported.
     let style = document.querySelector(`style[data-id="${styleDataId}"]`)
 
     if (!style) {
       style = document.createElement('style')
       style.setAttribute('data-id', styleDataId)
+      style.innerHTML = `
+        button[data-tts-react-control]:hover {
+          background-color: #ebeaeaa6 !important;
+        }
+        button[data-id="tts-react-replay"]:hover {
+          filter: brightness(0.98);
+        }
+      `
       document.head.appendChild(style)
     }
 
-    style.innerHTML = `
-      button[data-tts-react-control] {
-        margin: 0;
-        padding: ${padding[size]}px;
-        border: none;
-        border-radius: ${iconSizes[size]}px;
-        color: black;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background-color: transparent;
-      }
-      button[data-tts-react-control]:hover {
-        background-color: #ebeaeaa6;
-      }
-      button[data-id="tts-react-replay"] {
-        position: absolute;
-        background: #f2f1f1a6;
-        z-index: 9999;
-        ${trbl};
-      }
-      button[data-id="tts-react-replay"]:hover {
-        background: #ebeaeaa6;
-      }
-    `
-  }, [align, size])
+    return () => {
+      // Cleanup reference to DOM element
+      style = null
+    }
+  }, [align, size, type])
 
   return (
     <button
@@ -74,6 +91,7 @@ const Control = ({
       data-tts-react-control
       data-id={`tts-react-${type}`}
       onClick={onClick}
+      style={btnStyle}
       dangerouslySetInnerHTML={{ __html: svg }}
       {...rest}
     />

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -440,11 +440,11 @@ class Controller extends EventTarget {
       this.#synthesizer.load()
       await this.#playHtmlAudio()
     } else {
-      // Drop all utterances in the queue
-      this.#synthesizer.cancel()
       // Take out of any paused state
       this.#synthesizer.resume()
-      // Starat speaking from the beginning
+      // Drop all utterances in the queue
+      this.#synthesizer.cancel()
+      // Start speaking from the beginning
       this.#synthesizer.speak(this.#target as SpeechSynthesisUtterance)
     }
   }

--- a/src/hook.tsx
+++ b/src/hook.tsx
@@ -430,6 +430,8 @@ const useTts = ({
   // Controller event listeners
   const onStartHandler: TTSOnEvent = useCallback(
     (evt) => {
+      dispatch({ type: 'play' })
+
       if (typeof onStart === 'function') {
         onStart(evt.detail)
       }


### PR DESCRIPTION
FIXES:

* Updates `isPlaying` based on native browser events instead of `useTts` methods.
* Reverts back to mostly inline styles on `TextToSpeech` control buttons except for `pseudo-*` declarations to remove any flashes of un-styled content.